### PR TITLE
Fix snitch double benefits and click frequency

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,7 +808,6 @@
         id: "doubleClick",
         name: "Double Click Power",
         baseCost: 20,
-        revealAt: 10,
         scaling: 2.5,
         description: "Multiplies click power by 2",
       },
@@ -820,6 +819,8 @@
       credits: 0,
       ticks: 0,
       unbanked: 0,
+      // Tracks which upgrades have been revealed at least once
+      revealedUpgrades: {},
       // Shared button type multipliers
       buttonTypes: {
         // Action-type buttons: hunt, advance contract, etc.
@@ -982,9 +983,15 @@
             isMaxed = count >= REDUCE_CD_MAX_COUNT;
           }
           const count = (state.upgrades && state.upgrades[up.id]) || 0;
-          const revealThreshold = up.revealAt !== undefined ? up.revealAt : up.baseCost;
-          const shouldShow = count > 0 || state.credits >= revealThreshold;
+          const alreadyRevealed = !!(state.revealedUpgrades && state.revealedUpgrades[up.id]);
+          const shouldShow = alreadyRevealed || count > 0 || state.credits >= up.baseCost;
           if (!shouldShow) continue;
+          // Mark as revealed permanently once shown the first time
+          if (!alreadyRevealed) {
+            if (!state.revealedUpgrades) state.revealedUpgrades = {};
+            state.revealedUpgrades[up.id] = true;
+            try { save(); } catch {}
+          }
           const maxedClass = isMaxed ? "maxed" : "";
           const mobileClass = window.innerWidth <= 768 ? "upgrade-row-mobile" : "";
           html += `<div class="upgrade-row ${maxedClass} ${mobileClass}">
@@ -1103,6 +1110,9 @@
       if (state.credits < cost) return;
       state.credits -= cost;
       state.upgrades[up.id] = (state.upgrades[up.id] || 0) + 1;
+      // Ensure revealed flag persists once purchased
+      if (!state.revealedUpgrades) state.revealedUpgrades = {};
+      state.revealedUpgrades[up.id] = true;
       // Apply upgrade effect
       applyUpgradeEffect(up.id);
       try { save(); } catch {}
@@ -1208,6 +1218,10 @@
         }
         // Ensure upgrades is an object map
         if (!state.upgrades || typeof state.upgrades !== 'object') state.upgrades = {};
+        // Ensure revealedUpgrades map exists
+        if (!state.revealedUpgrades || typeof state.revealedUpgrades !== 'object') {
+          state.revealedUpgrades = {};
+        }
         // Ensure buttonTypes exists
         if (!state.buttonTypes || typeof state.buttonTypes !== 'object') {
           state.buttonTypes = { action: { base: 1, multiplier: 1 } };

--- a/index.html
+++ b/index.html
@@ -1241,19 +1241,20 @@
         
         // Calculate collective click interval (halving time with each snitch)
         const clickInterval = getSnitchClickInterval(snitch);
+        // Use fractional tracking to properly handle fractional intervals
         state.snitchClickTracking.lastClick += 1;
         
         if (state.snitchClickTracking.lastClick >= clickInterval) {
           // Time to autoclick!
-          state.snitchClickTracking.lastClick = 0;
+          // Keep the remainder to maintain precise timing
+          state.snitchClickTracking.lastClick = state.snitchClickTracking.lastClick - clickInterval;
           
           // Perform the autoclick action (respecting cooldowns)
           if (snitch.autoclickType === "action" && canClick('action')) {
-            // Add credits from autoclick
-            state.credits += getClickValue();
             startCooldown('action');
             
-            // If contract is active, also contribute to contract progress
+            // During contracts, Snitch contributes to contract progress instead of credits
+            // This maintains consistency with other game mechanics
             if (state.contractActive) {
               const contract = contracts[state.currentContract];
               state.contractProgress += getClickValue();
@@ -1264,6 +1265,9 @@
                 state.contractProgress = 0;
                 showToast(`Contract completed! +${contract.reward} credits`);
               }
+            } else {
+              // Only add credits when not in a contract
+              state.credits += getClickValue();
             }
           }
         }

--- a/index.html
+++ b/index.html
@@ -950,6 +950,14 @@
           hireRow.style.display = "none";
         }
       }
+      // Grey out Hire button when unaffordable or on cooldown
+      const hireButton = document.getElementById('hireBtn');
+      if (hireButton) {
+        const cd = state.cooldowns && state.cooldowns.hire;
+        const ready = !cd || (cd.ms === 0) || Date.now() >= (cd.readyAt || 0);
+        const canAfford = state.credits >= getCrewCost(novice);
+        hireButton.disabled = !(ready && canAfford);
+      }
       // Update click info text and toggle contract click button
       const clickInfo = document.getElementById("clickInfo");
       if (clickInfo) {
@@ -1396,6 +1404,12 @@
           b.style.setProperty('--cdw', (pct * 100).toFixed(1) + '%');
           b.disabled = true;
           anyCooling = true;
+        }
+        // Additional affordability rule for hire button
+        if (b.id === 'hireBtn') {
+          const novice = crewTypes[0];
+          const canAfford = state.credits >= getCrewCost(novice);
+          if (!canAfford) b.disabled = true;
         }
       }
       if (anyCooling) requestAnimationFrame(updateCooldownVisual);

--- a/index.html
+++ b/index.html
@@ -700,6 +700,17 @@
               <div id="hirePerTick" class="text-accent">+0.5 credits/tick</div>
               <div id="hireCostBelow" class="text-secondary">Hired: 0</div>
             </div>
+            
+            <div id="snitchHireRow" style="display:none;">
+              <div class="row">
+                <button id="snitchHireBtn" class="btn cooldownable" data-cooldown-type="hire">Hire Snitch (autoclicker)</button>
+              </div>
+              <div class="row">
+                <span id="snitchHireCostSpan" class="text-secondary">Cost: 100</span>
+              </div>
+              <div id="snitchPerTick" class="text-accent">Autoclicks every 1.0 tick</div>
+              <div id="snitchHireCostBelow" class="text-secondary">Hired: 0</div>
+            </div>
           </div>
         </aside>
 
@@ -780,6 +791,17 @@
         count: 0,
         revealed: false,
       },
+      {
+        id: "snitch",
+        name: "Snitch (autoclicker)",
+        baseCost: 1000,
+        scaling: 10,
+        perTick: 0,
+        count: 0,
+        revealed: false,
+        autoclickType: "action", // Type of button to autoclick
+        baseClickInterval: 1, // Base interval in ticks (1 tick = 1 second)
+      },
       // Future crew types can be added here
     ];
 
@@ -848,6 +870,12 @@
     // Calculate the cost for a crew type
     function getCrewCost(crew) {
       return Math.floor(crew.baseCost * Math.pow(crew.scaling, crew.count));
+    }
+
+    // Calculate the click interval for Snitches (halving time with each new snitch)
+    function getSnitchClickInterval(snitch) {
+      if (snitch.count === 0) return snitch.baseClickInterval;
+      return snitch.baseClickInterval / Math.pow(2, snitch.count);
     }
 
     // Button type click value
@@ -957,6 +985,43 @@
         const ready = !cd || (cd.ms === 0) || Date.now() >= (cd.readyAt || 0);
         const canAfford = state.credits >= getCrewCost(novice);
         hireButton.disabled = !(ready && canAfford);
+      }
+
+      // Snitch UI
+      const snitch = crewTypes[1];
+      const snitchHireCostSpan = document.getElementById("snitchHireCostSpan");
+      const snitchHireCostBelow = document.getElementById("snitchHireCostBelow");
+      if (snitchHireCostSpan) {
+        snitchHireCostSpan.textContent = `Cost: ${getCrewCost(snitch)}`;
+      }
+      if (snitchHireCostBelow) {
+        snitchHireCostBelow.textContent = `Hired: ${snitch.count}`;
+      }
+      const snitchPerTick = document.getElementById("snitchPerTick");
+      if (snitchPerTick) {
+        if (snitch.count === 0) {
+          snitchPerTick.innerHTML = `<span style='color:#9aa;'>Autoclicks every ${snitch.baseClickInterval.toFixed(1)} tick</span>`;
+        } else {
+          const interval = getSnitchClickInterval(snitch);
+          snitchPerTick.innerHTML = `<span style='color:#9aa;'>Autoclicks every ${interval.toFixed(1)} tick(s)</span>`;
+        }
+      }
+      const snitchHireRow = document.getElementById("snitchHireRow");
+      if (snitchHireRow) {
+        if (snitch.revealed || state.credits >= getCrewCost(snitch)) {
+          snitchHireRow.style.display = "";
+          snitch.revealed = true;
+        } else {
+          snitchHireRow.style.display = "none";
+        }
+      }
+      // Grey out Snitch Hire button when unaffordable or on cooldown
+      const snitchHireButton = document.getElementById('snitchHireBtn');
+      if (snitchHireButton) {
+        const cd = state.cooldowns && state.cooldowns.hire;
+        const ready = !cd || (cd.ms === 0) || Date.now() >= (cd.readyAt || 0);
+        const canAfford = state.credits >= getCrewCost(snitch);
+        snitchHireButton.disabled = !(ready && canAfford);
       }
       // Update click info text and toggle contract click button
       const clickInfo = document.getElementById("clickInfo");
@@ -1073,6 +1138,22 @@
         state.credits -= cost;
         novice.count += 1;
         startCooldown('hire');
+        showToast(`Hired ${novice.name}! +${novice.perTick} credits/tick`);
+        updateUI();
+      });
+    }
+
+    const snitchHireBtn = document.getElementById("snitchHireBtn");
+    if (snitchHireBtn) {
+      snitchHireBtn.addEventListener("click", () => {
+        if (!canClick('hire')) return;
+        const snitch = crewTypes[1];
+        const cost = getCrewCost(snitch);
+        if (state.credits < cost) return;
+        state.credits -= cost;
+        snitch.count += 1;
+        startCooldown('hire');
+        showToast(`Hired ${snitch.name}! Autoclicks every ${getSnitchClickInterval(snitch).toFixed(1)} tick(s)`);
         updateUI();
       });
     }
@@ -1092,6 +1173,7 @@
           state.credits += contract.reward;
           state.contractActive = false;
           state.contractProgress = 0;
+          showToast(`Contract completed! +${contract.reward} credits`);
         }
         // Update progress number live if visible
         const progressNum = document.getElementById('contractProgressNum');
@@ -1149,6 +1231,44 @@
     const tickId = setInterval(() => {
       state.ticks += 1;
 
+      // Handle Snitch autoclicking
+      const snitch = crewTypes[1];
+      if (snitch.count > 0) {
+        // Initialize snitch click tracking if not exists
+        if (!state.snitchClickTracking) {
+          state.snitchClickTracking = { lastClick: 0 };
+        }
+        
+        // Calculate collective click interval (halving time with each snitch)
+        const clickInterval = getSnitchClickInterval(snitch);
+        state.snitchClickTracking.lastClick += 1;
+        
+        if (state.snitchClickTracking.lastClick >= clickInterval) {
+          // Time to autoclick!
+          state.snitchClickTracking.lastClick = 0;
+          
+          // Perform the autoclick action (respecting cooldowns)
+          if (snitch.autoclickType === "action" && canClick('action')) {
+            // Add credits from autoclick
+            state.credits += getClickValue();
+            startCooldown('action');
+            
+            // If contract is active, also contribute to contract progress
+            if (state.contractActive) {
+              const contract = contracts[state.currentContract];
+              state.contractProgress += getClickValue();
+              if (state.contractProgress >= contract.goal) {
+                state.contractProgress = contract.goal;
+                state.credits += contract.reward;
+                state.contractActive = false;
+                state.contractProgress = 0;
+                showToast(`Contract completed! +${contract.reward} credits`);
+              }
+            }
+          }
+        }
+      }
+
       // If contract is active, increment contract progress instead of credits
       if (state.contractActive) {
         const contract = contracts[state.currentContract];
@@ -1164,6 +1284,7 @@
           state.credits += contract.reward;
           state.contractActive = false;
           state.contractProgress = 0;
+          showToast(`Contract completed! +${contract.reward} credits`);
         }
       } else {
         // Calculate passive income from all crew
@@ -1200,6 +1321,8 @@
         if (hintEl) { try { hintEl.remove(); } catch {} }
         try { save(); } catch {}
         startCooldown('action');
+        const contract = contracts[state.currentContract];
+        showToast(`Contract taken: ${contract.description}`);
         updateUI();
       }
     });
@@ -1272,6 +1395,10 @@
         updateCooldownFromUpgrades();
         // Ensure click power multiplier reflects upgrades
         updateClickPowerFromUpgrades();
+        // Ensure snitch click tracking exists
+        if (!state.snitchClickTracking) {
+          state.snitchClickTracking = { lastClick: 0 };
+        }
       } catch {}
     }
 

--- a/index.html
+++ b/index.html
@@ -706,7 +706,7 @@
                 <button id="snitchHireBtn" class="btn cooldownable" data-cooldown-type="hire">Hire Snitch (autoclicker)</button>
               </div>
               <div class="row">
-                <span id="snitchHireCostSpan" class="text-secondary">Cost: 100</span>
+                <span id="snitchHireCostSpan" class="text-secondary"></span>
               </div>
               <div id="snitchPerTick" class="text-accent">Autoclicks every 1.0 tick</div>
               <div id="snitchHireCostBelow" class="text-secondary">Hired: 0</div>

--- a/index.html
+++ b/index.html
@@ -708,7 +708,7 @@
               <div class="row">
                 <span id="snitchHireCostSpan" class="text-secondary"></span>
               </div>
-              <div id="snitchPerTick" class="text-accent">Autoclicks every 1.0 tick</div>
+              <div id="snitchPerTick" class="text-accent"></div>
               <div id="snitchHireCostBelow" class="text-secondary">Hired: 0</div>
             </div>
           </div>
@@ -875,7 +875,7 @@
     // Calculate the click interval for Snitches (halving time with each new snitch)
     function getSnitchClickInterval(snitch) {
       if (snitch.count === 0) return snitch.baseClickInterval;
-      return snitch.baseClickInterval / Math.pow(2, snitch.count);
+      return snitch.baseClickInterval / Math.pow(2, snitch.count - 1);
     }
 
     // Button type click value
@@ -944,6 +944,15 @@
     function canHuntClick() { return canClick('action'); }
     function startHuntCooldown() { return startCooldown('action'); }
 
+    // Reusable function to complete contracts and award rewards
+    function completeContract(contract) {
+      state.contractProgress = contract.goal;
+      state.credits += contract.reward;
+      state.contractActive = false;
+      state.contractProgress = 0;
+      showToast(`Contract completed! +${contract.reward} credits`);
+    }
+
     function updateUI() {
       $("credits").textContent = fmt0(state.credits);
       $("ticks").textContent = fmt0(state.ticks);
@@ -963,10 +972,10 @@
       const hirePerTick = document.getElementById("hirePerTick");
       if (hirePerTick) {
         if (novice.count === 0) {
-          hirePerTick.innerHTML = `<span style='color:#9aa;'>+${novice.perTick}</span> credits/tick`;
+          hirePerTick.innerHTML = `<span class="text-accent">+${novice.perTick}</span> credits/tick`;
         } else {
           const totalPerTick = (novice.count * novice.perTick).toFixed(1);
-          hirePerTick.innerHTML = `<span style='color:#9aa;'>+${totalPerTick}</span> credits/tick`;
+          hirePerTick.innerHTML = `<span class="text-accent">+${totalPerTick}</span> credits/tick`;
         }
       }
       const hireRow = document.getElementById("hireRow");
@@ -1000,10 +1009,10 @@
       const snitchPerTick = document.getElementById("snitchPerTick");
       if (snitchPerTick) {
         if (snitch.count === 0) {
-          snitchPerTick.innerHTML = `<span style='color:#9aa;'>Autoclicks every ${snitch.baseClickInterval.toFixed(1)} tick</span>`;
+          snitchPerTick.innerHTML = `<span class="text-accent">Autoclicks every ${snitch.baseClickInterval.toFixed(1)} tick</span>`;
         } else {
           const interval = getSnitchClickInterval(snitch);
-          snitchPerTick.innerHTML = `<span style='color:#9aa;'>Autoclicks every ${interval.toFixed(1)} tick(s)</span>`;
+          snitchPerTick.innerHTML = `<span class="text-accent">Autoclicks every ${interval.toFixed(1)} tick(s)</span>`;
         }
       }
       const snitchHireRow = document.getElementById("snitchHireRow");
@@ -1168,12 +1177,8 @@
         const contract = contracts[state.currentContract];
         state.contractProgress += add;
         if (state.contractProgress >= contract.goal) {
-          state.contractProgress = contract.goal;
           // Complete contract immediately on click
-          state.credits += contract.reward;
-          state.contractActive = false;
-          state.contractProgress = 0;
-          showToast(`Contract completed! +${contract.reward} credits`);
+          completeContract(contract);
         }
         // Update progress number live if visible
         const progressNum = document.getElementById('contractProgressNum');
@@ -1259,11 +1264,7 @@
               const contract = contracts[state.currentContract];
               state.contractProgress += getClickValue();
               if (state.contractProgress >= contract.goal) {
-                state.contractProgress = contract.goal;
-                state.credits += contract.reward;
-                state.contractActive = false;
-                state.contractProgress = 0;
-                showToast(`Contract completed! +${contract.reward} credits`);
+                completeContract(contract);
               }
             } else {
               // Only add credits when not in a contract
@@ -1283,12 +1284,8 @@
         state.contractProgress += contractPerTick;
         // Clamp progress
         if (state.contractProgress >= contract.goal) {
-          state.contractProgress = contract.goal;
           // Award credits and end contract
-          state.credits += contract.reward;
-          state.contractActive = false;
-          state.contractProgress = 0;
-          showToast(`Contract completed! +${contract.reward} credits`);
+          completeContract(contract);
         }
       } else {
         // Calculate passive income from all crew


### PR DESCRIPTION
Fix Snitch autoclicker to resolve double benefits, correct click interval calculation, improve UI dynamism, and centralize contract completion logic.

The Snitch autoclicker previously granted both credits and contract progress during active contracts, which was inconsistent with other game mechanics. Its click interval calculation also had a bug where the first Snitch's interval was halved, and the fractional tracking was incorrect. Furthermore, the Snitch UI contained hardcoded values and inline styles, and the contract completion logic was duplicated in multiple places, leading to maintenance difficulties. This PR resolves these issues for correct functionality, a dynamic UI, and improved code maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cbe1891-f93a-4bcb-9233-85870215f02c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9cbe1891-f93a-4bcb-9233-85870215f02c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

