### PR TITLE
Move getTickText and remove redundant contract progress assignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -962,9 +962,13 @@
     function canHuntClick() { return canClick('action'); }
     function startHuntCooldown() { return startCooldown('action'); }
 
+    // Helper function to determine singular/plural tick text
+    function getTickText(interval) {
+      return Math.abs(interval - SINGLE_TICK_THRESHOLD) < TICK_INTERVAL_TOLERANCE ? "tick" : "ticks";
+    }
+
     // Reusable function to complete contracts and award rewards
     function completeContract(contract) {
-      state.contractProgress = contract.goal;
       state.credits += contract.reward;
       state.contractActive = false;
       state.contractProgress = 0;
@@ -1040,10 +1044,6 @@
         snitchPerTick.innerHTML = `<span class="text-accent">Autoclicks every ${interval.toFixed(1)} ${tickText}</span>`;
       }
 
-// Helper function to determine singular/plural tick text
-function getTickText(interval) {
-  return Math.abs(interval - SINGLE_TICK_THRESHOLD) < TICK_INTERVAL_TOLERANCE ? "tick" : "ticks";
-}
       const snitchHireRow = document.getElementById("snitchHireRow");
       if (snitchHireRow) {
         if (snitch.revealed || state.credits >= getCrewCost(snitch)) {
@@ -1196,7 +1196,7 @@ function getTickText(interval) {
         snitch.count += 1;
         startCooldown('hire');
         const interval = getSnitchClickInterval(snitch);
-        const tickText = Math.abs(interval - SINGLE_TICK_THRESHOLD) < TICK_INTERVAL_TOLERANCE ? "tick" : "ticks";
+        const tickText = getTickText(interval);
         showToast(`Hired ${snitch.name}! Autoclicks every ${interval.toFixed(1)} ${tickText}`);
         updateUI();
       });


### PR DESCRIPTION
Refactor `getTickText` to global scope and remove redundant `state.contractProgress` assignment to improve code organization, reusability, and efficiency.

---
<a href="https://cursor.com/background-agent?bcId=bc-927a90ba-27fd-48e2-85f7-c958d8501c59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-927a90ba-27fd-48e2-85f7-c958d8501c59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

