### PR TITLE
Fix snitch button cooldown and responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -1469,14 +1469,8 @@
           snitchHireRow.classList.add("hidden");
         }
       }
-      // Grey out Snitch Hire button when unaffordable or on cooldown
-      const snitchHireButton = document.getElementById('snitchHireBtn');
-      if (snitchHireButton) {
-        const cd = state.cooldowns && state.cooldowns.hire;
-        const ready = !cd || (cd.ms === 0) || Date.now() >= (cd.readyAt || 0);
-        const canAfford = state.credits >= getCrewCost(snitch);
-        snitchHireButton.disabled = !(ready && canAfford);
-      }
+      // Snitch Hire button disabled state is now handled in updateCooldownVisual()
+      // for continuous monitoring of both cooldown and affordability
       // Update click info text and toggle contract click button
       const clickInfo = document.getElementById("clickInfo");
       if (clickInfo) {
@@ -1944,8 +1938,25 @@
           const canAfford = state.credits >= getCrewCost(novice);
           if (!canAfford) b.disabled = true;
         }
+        // Handle Snitch hire button disabled state (cooldown + affordability)
+        // This ensures the button state is continuously monitored for smooth transitions
+        if (b.id === 'snitchHireBtn') {
+          const snitch = crewTypes[1];
+          const canAfford = state.credits >= getCrewCost(snitch);
+          const snitchReady = total === 0 || now >= readyAt;
+          b.disabled = !(snitchReady && canAfford);
+        }
       }
-      if (anyCooling) requestAnimationFrame(updateCooldownVisual);
+      // Continue monitoring for state changes, especially for Snitch hire button
+      // which needs continuous updates for both cooldown and affordability
+      // Use a small delay to prevent excessive calls while ensuring responsiveness
+      if (anyCooling) {
+        requestAnimationFrame(updateCooldownVisual);
+      } else {
+        // Even when no cooldowns are active, continue monitoring for a short time
+        // to catch state transitions smoothly
+        setTimeout(() => requestAnimationFrame(updateCooldownVisual), 50);
+      }
     }
 
     let autosaveEnabled = true;


### PR DESCRIPTION
Fix Snitch hire button's disabled state to prevent visual glitches and ensure immediate responsiveness after cooldown.

The Snitch button's disabled state was previously managed in `updateUI()`, which isn't called continuously, while the cooldown visual updates were in `updateCooldownVisual()`. This created a timing mismatch, causing the button to briefly appear clickable during cooldowns or have delayed state transitions. The fix unifies the state management within `updateCooldownVisual()` and ensures it continues monitoring for state changes even when no active cooldowns are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-59abef6f-5c9e-44c7-800d-de20e0c84337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59abef6f-5c9e-44c7-800d-de20e0c84337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

