### PR TITLE
Hide advance contract button outside active contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repository Agent Instructions
+
+- Use two spaces for indentation in HTML, CSS, and JavaScript.
+- Run `npm test` and `npm run lint` if available before committing.
+- Update both `README.md` and `AGENTS.md` with every change.
+
+## Changelog
+
+- Ensure the "Advance contract" button hides when no contract is active.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Bounty Idle is a browser-based incremental game that combines strategic resource
 - **Cooldown System**: Strategic timing for optimal gameplay
 - **Passive Income**: Crew members generate credits automatically
 - **Contract Progress**: Long-term goals with substantial rewards
+- **Contextual Contract Actions**: The "Advance contract" button only appears during active contracts and hides afterward
 - **Auto-save**: Automatic game saving every 30 seconds
 - **Mobile Responsive**: Optimized for both desktop and mobile devices
 

--- a/index.html
+++ b/index.html
@@ -1384,6 +1384,7 @@
       state.contractActive = false;
       state.contractProgress = 0;
       showToast(`Contract completed! +${contract.reward} credits`);
+      updateUI();
     }
 
     // Reusable function to check and complete contracts if goal is reached


### PR DESCRIPTION
## Summary
- Ensure the "Advance contract" button only appears during active contracts
- Document contract button behavior
- Add repository instructions for future contributors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b38887ad80832b8af8bf60a2af97ff