### PR TITLE
Fix advance contract button visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
 
       /* Utility classes for display states */
       .hidden {
-        display: none;
+        display: none !important;
       }
 
       /* Margin utility classes */
@@ -1544,13 +1544,10 @@
       }
       const contractClickBtn = document.getElementById("contractClickBtn");
       if (contractClickBtn) {
-        console.log("UpdateUI: contractActive =", state.contractActive, "button has hidden class:", contractClickBtn.classList.contains("hidden"));
         if (state.contractActive) {
           contractClickBtn.classList.remove("hidden");
-          console.log("Showing contract button");
         } else {
           contractClickBtn.classList.add("hidden");
-          console.log("Hiding contract button");
         }
       }
 


### PR DESCRIPTION
Add `!important` to the `.hidden` CSS class to correctly hide the "Advance Contract" button when no contract is active.

The "Advance Contract" button was always visible due to a CSS specificity conflict. The `.btn` class's `display: inline-flex` was overriding the `.hidden` class's `display: none` because both had equal specificity and `.btn` was defined later in the stylesheet. Adding `!important` ensures `.hidden` takes precedence.

---
<a href="https://cursor.com/background-agent?bcId=bc-255db2b3-e6c3-4d0f-a2fe-98ce9c8fae78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-255db2b3-e6c3-4d0f-a2fe-98ce9c8fae78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

