### PR TITLE
Fix CRT opacity and duplicate key listeners

### DIFF
--- a/game.js
+++ b/game.js
@@ -655,12 +655,8 @@ class GameManager {
       this.resetSettings();
     });
 
-    // Close on escape key
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape") {
-        this.closeSettingsMenu();
-      }
-    });
+    // Note: Escape key handling is now managed by the dev menu setupDevMenuEvents()
+    // to avoid conflicts between multiple event listeners
   }
 
   openSettingsMenu() {
@@ -735,9 +731,10 @@ class GameManager {
     
     crtCorners.style.transform = `perspective(${cornerPerspective}px) rotateX(${cornerRotationX}deg) rotateY(${cornerRotationY}deg)`;
     
-    // Keep opacity at 1 to avoid darkening
-    crtScreen.style.opacity = 1;
-    crtCorners.style.opacity = 1;
+    // Remove hardcoded opacity to allow CSS calculations to work properly
+    // The CSS already handles opacity based on --crt-strength variable
+    crtScreen.style.removeProperty('opacity');
+    crtCorners.style.removeProperty('opacity');
   }
 
   applySettings() {
@@ -967,11 +964,18 @@ GameManager.prototype.setupDevMenuEvents = function() {
       koriBuffer = ''; // Reset buffer after opening
     }
     
-    // ESC key to close dev menu
+    // ESC key to close dev menu or settings menu
     if (e.key === 'Escape') {
       const devPanel = this.getElement("devMenuPanel");
+      const settingsPanel = this.getElement("settingsMenuPanel");
+      
+      // Close dev menu if open
       if (devPanel && !devPanel.classList.contains('hidden')) {
         this.toggleDevMenu();
+      }
+      // Close settings menu if open
+      else if (settingsPanel && !settingsPanel.classList.contains('hidden')) {
+        this.closeSettingsMenu();
       }
     }
   });


### PR DESCRIPTION
Remove hardcoded CRT opacity and consolidate Escape key handling to fix strength slider and menu conflicts.

The hardcoded `opacity = 1` in `updateCrtWarping` overrode CSS calculations using `--crt-strength`, making the CRT strength slider ineffective. Additionally, separate `keydown` listeners for 'Escape' in both `setupSettingsMenuEvents` and `setupDevMenuEvents` led to conflicting behavior when closing menus. This PR addresses both issues by allowing CSS to control CRT opacity and centralizing Escape key handling in `setupDevMenuEvents`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e73438b-a634-4e5b-8594-35301ec541cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e73438b-a634-4e5b-8594-35301ec541cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

